### PR TITLE
fix: Login Retry Logic

### DIFF
--- a/services/authService.js
+++ b/services/authService.js
@@ -1,4 +1,5 @@
 const {axiosService} = require("./axiosService");
+const {delay} = require("../utils/utils");
 
 const login = async (email, password) => {
     const loginBody = {
@@ -6,8 +7,16 @@ const login = async (email, password) => {
         password: password
     }
 
-    const loginResponse = await axiosService.post('/v1/auth/login', loginBody);
-    return loginResponse.data.token
+    while (true) {
+        try {
+            const loginResponse = await axiosService.post('/v1/auth/login', loginBody);
+            return loginResponse.data.token
+        } catch (e) {
+            console.error(`Caught error when trying to login, likely a timeout error. Error: ${e.status ?? e.name}`)
+            console.log('Retrying login in 1 minute...')
+            await delay(60000)
+        }
+    }
 }
 
 module.exports = { login }


### PR DESCRIPTION
_Why_
1. API was taking too long overnight, resulting in 503 responses for both card battle and market price schedulers.
2. This allows for retry logic to occur within both schedulers to account for slow start up.